### PR TITLE
Remove useless subselect when fetching cover art

### DIFF
--- a/src/storage/sql_storage.cc
+++ b/src/storage/sql_storage.cc
@@ -1240,12 +1240,7 @@ String SQLStorage::findFolderImage(int id, String trackArtBase)
        << "LIKE " << quote(_("folder.jp%"));
     *q << " ) AND ";
     *q << TQ("upnp_class") << '=' << quote(_(UPNP_DEFAULT_CLASS_IMAGE_ITEM)) << " AND ";
-    *q << TQ("parent_id") << " IN ";
-    *q << "(";
-    *q << "SELECT " << TQ("parent_id") << " FROM " << TQ(CDS_OBJECT_TABLE) << " WHERE ";
-    *q << TQ("parent_id") << '=' << quote(String::from(id)) << " AND ";
-    *q << TQ("object_type") << '=' << quote(OBJECT_TYPE_ITEM);
-    *q << ")";
+    *q << TQ("parent_id") << '=' << quote(String::from(id));
     *q << " ORDER BY " << TQ("dc_title") << " DESC";
 
     //log_debug("findFolderImage %d, %s\n", id, q->c_str());


### PR DESCRIPTION
This improves UPnP browsing speed quite a lot on MySQL.

It does not change the current behavior, which is providing folder.jpg as container image.

Resolves: https://github.com/v00d00/gerbera/issues/75