### PR TITLE
Fix broken build when WITH_JS=0, duktape patch for OmniOS/Solaris

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ set(gerbera_PATCH_VERSION     0)
 set(gerbera_RELEASE           "alpha")
 set(gerbera_SUFFIX            "")
 
-add_library(libgerbera OBJECT
+set(libgerberaFILES
         src/action_request.cc
         src/action_request.h
         src/atrailers_content_handler.cc
@@ -160,7 +160,6 @@ add_library(libgerbera OBJECT
         src/scripting/runtime.h
         src/scripting/script.cc
         src/scripting/script.h
-        src/scripting/duktape/duktape.c
         src/server.cc
         src/serve_request_handler.cc
         src/serve_request_handler.h
@@ -276,6 +275,10 @@ add_library(libgerbera OBJECT
         src/zmm/strings.cc
         src/zmm/strings.h
         src/zmm/zmm.h)
+if(WITH_JS)
+    set(libgerberaFILES ${libgerberaFILES} src/scripting/duktape/duktape.c)
+endif()
+add_library(libgerbera OBJECT ${libgerberaFILES})
 
 target_include_directories(libgerbera PRIVATE "${CMAKE_SOURCE_DIR}/src")
 

--- a/src/scripting/duktape/README.duktape
+++ b/src/scripting/duktape/README.duktape
@@ -1,5 +1,5 @@
 To update the embedded Duktape distribution, grab a Duktape tarball or git
-clone and it into <DUKTAPE_SRC>, then simply launch the following command
+clone it into <DUKTAPE_SRC>, then simply launch the following command
 from Gerbera top directory:
 
-python2 <DUKTAPE_SRC> --output-directory src/scripting/duktape -DDUK_USE_CPP_EXCEPTIONS
+python2 <DUKTAPE_SRC>/tools/config.py --output-directory src/scripting/duktape -DDUK_USE_CPP_EXCEPTIONS

--- a/src/scripting/duktape/duk_config.h
+++ b/src/scripting/duktape/duk_config.h
@@ -634,7 +634,7 @@
 #define DUK_USE_BYTEORDER 3
 #endif
 #else  /* DUK_F_OLD_SOLARIS */
-#include <ast/endian.h>
+#include <sys/param.h>
 #endif  /* DUK_F_OLD_SOLARIS */
 
 #include <sys/param.h>


### PR DESCRIPTION
duktape.o was always built even when WITH_JS unset, and this would fail since duktape.c is actually C++ but the compile switch was only done in the WITH_JS branch.
Cleanup duktape README.  
Quick patch for OmniOS/Solaris to duk_config.h, pending upstream patch svaarala/duktape#1514
  for extra hilarity, committing a change to the duktape git repo triggers a git fsck bug on OmniOS; had to do that from Ubuntu