### PR TITLE
Fix #86 - SessionManager checkTimer deadlock

### DIFF
--- a/src/timer.h
+++ b/src/timer.h
@@ -41,7 +41,7 @@
 #include <condition_variable>
 #include <list>
 
-class Timer : public Singleton<Timer, std::mutex> {
+class Timer : public Singleton<Timer, std::recursive_mutex> {
 public:
     /// \brief This is the parameter class for timerNotify
     class Parameter : public zmm::Object {


### PR DESCRIPTION
@v00d00 - Here is the `SessionManager::checkTimer()` deadlock fix.

1. Change `Timer` class to `recursive_mutex` - allowing calls for lock multiple times from same thread
2. Add intermediary `std::list` to avoid corruption of the `subscribers` list when iterating, then deleting a subscriber

I did the following tests.

1. Build and Run **gerbera**
2. Login/Logout
3. Wait for Session Timeout
4. Add Timed scan on a directory

I noticed that the project does not have any unit tests.  To that end, I also created the start of unit tests using GoogleTest.

Let me know if you think any additional tests are warranted (i.e. Travis CI build?).

>Please consider my experience level with C++ is **novice** so any best practices or bad behaviors feel free to point out directly.

Thanks,

Eamonn