### PR TITLE
Fix #86 - SessionManager checkTimer deadlock

### DIFF
--- a/src/timer.h
+++ b/src/timer.h
@@ -97,8 +97,7 @@ protected:
     class TimerSubscriberElement {
     public:
         TimerSubscriberElement(Subscriber* subscriber, unsigned int notifyInterval, zmm::Ref<Parameter> parameter, bool once = false)
-            : disabled(false)
-            , subscriber(subscriber)
+            : subscriber(subscriber)
             , notifyInterval(notifyInterval)
             , parameter(parameter)
             , once(once)
@@ -125,7 +124,6 @@ protected:
             return subscriber == other.subscriber && parameter == other.parameter;
         }
         bool isOnce() const { return once; }
-        bool disabled;
 
     protected:
         Subscriber* subscriber;


### PR DESCRIPTION
Hello, here is round 2 for #86.  C++ won round 1.  Thanks to @gburca for suggestion on solution.

I was able to run **gerbera** locally, watch a few movies & listen to music.  The subscribers were cleaned up as expected when new web sessions were created, and timed out.  No obvious memory leaks after running for a few hours.

The only item **NOT** tested is the `element.isOnce()` condition.  Not sure how to test that directly?

Let me know what you think.  Any guidance on C++ convention and standard is appreciated. 👍 