### PR TITLE
Re-enable Virtual Folder album art

### DIFF
--- a/src/storage/sql_storage.cc
+++ b/src/storage/sql_storage.cc
@@ -1236,7 +1236,28 @@ String SQLStorage::findFolderImage(int id, String trackArtBase)
        << "LIKE " << quote(_("folder.jp%"));
     *q << " ) AND ";
     *q << TQ("upnp_class") << '=' << quote(_(UPNP_DEFAULT_CLASS_IMAGE_ITEM)) << " AND ";
+#ifndef ONLY_REAL_FOLDER_ART
+    *q << "( ";
+    *q <<       "( ";
+        // virtual listing via Album, Artist etc
+    *q << TQ("parent_id") << " IN ";
+    *q <<       "(";
+    *q << "SELECT " << TQ("parent_id") << " FROM " << TQ(CDS_OBJECT_TABLE) << " WHERE ";
+    *q << TQ("upnp_class") << '=' << quote(_(UPNP_DEFAULT_CLASS_MUSIC_TRACK)) << " AND ";
+    *q << TQ("id") << " IN ";
+    *q <<               "(";
+    *q << "SELECT " << TQ("ref_id") << " FROM " << TQ(CDS_OBJECT_TABLE) << " WHERE ";
+    *q << TQ("parent_id") << '=' << quote(String::from(id)) << " AND ";
+    *q << TQ("object_type") << '=' << quote(OBJECT_TYPE_ITEM);
+    *q <<               ")";
+    *q <<       ")";
+    *q << "     ) OR ";
+#endif
+        // straightforward folder listing of real filesystem
     *q << TQ("parent_id") << '=' << quote(String::from(id));
+#ifndef ONLY_REAL_FOLDER_ART
+    *q << ")";
+#endif
     *q << " ORDER BY " << TQ("dc_title") << " DESC";
 
     //log_debug("findFolderImage %d, %s\n", id, q->c_str());


### PR DESCRIPTION
I've now found the use-case, using eg foobar2000, where Virtual Folder cover art isn't returned.
the cover.jpg/etc artwork was implemented to work when using "PC Filesystem" mode in
DLNA clients.  Browsing via for example "Audio" then "Artists" was not working,
as the virtual root didn't match the physical.  Now both cases properly return
file-based cover art.

In case #75 reappears for MySQL folk, there is currently a define `ONLY_REAL_FOLDER_ART ` to disable this addition.
I note that in my scenario [six thousand albums] returning "Audio/Albums" hits the network timeout for
foobar2000 mobile, whether or not `ONLY_REAL_FOLDER_ART` is enabled.  With Sqllite, peformance
is otherwise fine in either case.