### PR TITLE
Fix minor spelling mistake

### DIFF
--- a/src/web_request_handler.h
+++ b/src/web_request_handler.h
@@ -149,7 +149,7 @@ public:
                                      IN enum UpnpOpenFileMode mode,
                                      IN zmm::String range);
     
-    /// \brief This method must be overriden by the subclasses that actually process the given request.
+    /// \brief This method must be overridden by the subclasses that actually process the given request.
     virtual void process() = 0;
     
     /// \brief builds full path to a script for the given relative filename


### PR DESCRIPTION
This was in one of Debian's mediatomb patches so it seemed sensible to submit it upstream so that patch can be dropped.