### PR TITLE
lastfmlib install script

### DIFF
--- a/scripts/install-lastfm.sh
+++ b/scripts/install-lastfm.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -ex
+LASTFM_VERSION="0.4.0"
+wget "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/lastfmlib/lastfmlib-${LASTFM_VERSION}.tar.gz"
+tar -xzvf "lastfmlib-${LASTFM_VERSION}.tar.gz"
+cd "lastfmlib-${LASTFM_VERSION}"
+./configure --prefix=/usr
+make
+make install


### PR DESCRIPTION
Completes #107 

Similar to any other install script in the `scripts/` directory, run it using bash. It requires a c++ compiler, libcurl, make, pkg-config and wget to run.