### PR TITLE
Fix port number confusion

### DIFF
--- a/src/config_manager.cc
+++ b/src/config_manager.cc
@@ -68,7 +68,7 @@ String ConfigManager::magic = nullptr;
 bool ConfigManager::debug_logging = false;
 String ConfigManager::ip = nullptr;
 String ConfigManager::interface = nullptr;
-int ConfigManager::port = -1;
+int ConfigManager::port = 0;
 
 ConfigManager::~ConfigManager()
 {
@@ -678,7 +678,7 @@ void ConfigManager::migrate()
             String host = getOption(_("/server/storage/host"));
             String db = getOption(_("/server/storage/database"));
             String username = getOption(_("/server/storage/username"));
-            int port = -1;
+            int port = 0
 
             if (server->getChildByName(_("storage"))->getChildByName(_("port")) != nullptr)
                 port = getIntOption(_("/server/storage/port"));
@@ -697,7 +697,7 @@ void ConfigManager::migrate()
 
             mysql->appendTextChild(_("host"), host);
 
-            if (port != -1)
+            if (port > 0)
                 mysql->appendTextChild(_("port"), String::from(port));
 
             if (socket != nullptr)
@@ -1509,7 +1509,7 @@ void ConfigManager::validate(String serverhome)
 #endif
 
     // 0 means, that the SDK will any free port itself
-    if (port < 0) {
+    if (port <= 0) {
         temp_int = getIntOption(_("/server/port"), 0);
     } else {
         temp_int = port;

--- a/src/config_manager.h
+++ b/src/config_manager.h
@@ -246,7 +246,7 @@ public:
                               zmm::String _prefix_dir = _(PACKAGE_DATADIR),
                               zmm::String _magic = nullptr,
                               bool _debug_logging = false,
-                              zmm::String _ip = nullptr, zmm::String _interface = nullptr, int _port = -1);
+                              zmm::String _ip = nullptr, zmm::String _interface = nullptr, int _port = 0);
 
     static bool isDebugLogging() { return debug_logging; };
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -83,7 +83,7 @@ void signal_handler(int signum);
 int main(int argc, char** argv, char** envp)
 {
     char* err = nullptr;
-    int port = -1;
+    int port = 0;
     struct sigaction action;
     sigset_t mask_set;
 
@@ -319,6 +319,7 @@ For more information visit " DESC_MANUFACTURER_URL "\n\n");
     ConfigManager::setStaticArgs(config_file, home, confdir, prefix, magic, debug_logging, ip, interface, port);
     try {
         ConfigManager::getInstance();
+        port = ConfigManager::getInstance()->getIntOption(CFG_SERVER_PORT);
     } catch (const mxml::ParseException& pe) {
         log_error("Error parsing config file: %s line %d:\n%s\n",
             pe.context->location.c_str(),


### PR DESCRIPTION
* Use throughout port 0 as default unassinged port which is documented in
the original config.xml for the server as well as the MySQL storage
backend.
* Re-read port from ConfigManager in main.cc to print out eventually
changed port in error cases.

This cleans up inconsistensions from dynamically assigned, command line provided or config.xml provided server port. Proper, consistent port is reflected in log output.