### PR TITLE
Fixing "error: expected ‘,’ or ‘;’ before ‘if’" at compile time

### DIFF
--- a/src/config_manager.cc
+++ b/src/config_manager.cc
@@ -682,13 +682,12 @@ void ConfigManager::migrate()
             String host = getOption(_("/server/storage/host"));
             String db = getOption(_("/server/storage/database"));
             String username = getOption(_("/server/storage/username"));
-            int port = 0
+            int port = 0;
 
             if (server->getChildByName(_("storage"))->getChildByName(_("port")) != nullptr)
                 port = getIntOption(_("/server/storage/port"));
 
             String socket = nullptr;
-            ;
             if (server->getChildByName(_("storage"))->getChildByName(_("socket")) != nullptr)
                 socket = getOption(_("/server/storage/socket"));
 


### PR DESCRIPTION
Compiling gerbera with mysql support enabled, exit with the above error as there was a ; in the wrong place