### PR TITLE
Fix #43 - Add compile information and git revision

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -333,7 +333,13 @@ add_definitions(-DPACKAGE_NAME="gerbera${gerbera_SUFFIX}")
 add_definitions(-DVERSION="${gerbera_MAJOR_VERSION}.${gerbera_MINOR_VERSION}.${gerbera_PATCH_VERSION}${gerbera_RELEASE}${gerbera_SUFFIX}")
 add_definitions(-DPACKAGE_DATADIR="${CMAKE_INSTALL_PREFIX}/share/gerbera")
 
-add_definitions(-DCOMPILE_INFO="")
+# Generate Compile Information
+include("GenCompileInfo")
+generate_compile_info()
+add_definitions(-DCOMPILE_INFO="${COMPILE_INFO}")
+add_definitions(-DGIT_BRANCH="${GIT_BRANCH}")
+add_definitions(-DGIT_COMMIT_HASH="${GIT_COMMIT_HASH}")
+
 add_definitions(-DEXTERNAL_TRANSCODING -DAUTO_CREATE_DATABASE)
 
 if (WITH_LOGGING OR WITH_DEBUG_LOGGING)

--- a/cmake/GenCompileInfo.cmake
+++ b/cmake/GenCompileInfo.cmake
@@ -1,0 +1,55 @@
+#
+# Generate the list of compile options
+# used to compile Gerbera
+#
+# Identify the Git branch and revision
+# if the directory has .git/ folder
+#
+function(generate_compile_info)
+    set(COMPILE_INFO_LIST
+            "WITH_MAGIC=${WITH_MAGIC}"
+            "WITH_MYSQL=${WITH_MYSQL}"
+            "WITH_CURL=${WITH_CURL}"
+            "WITH_INOTIFY=${WITH_INOTIFY}"
+            "WITH_JS=${WITH_JS}"
+            "WITH_TAGLIB=${WITH_TAGLIB}"
+            "WITH_AVCODEC=${WITH_AVCODEC}"
+            "WITH_FFMPEGTHUMBNAILER=${WITH_FFMPEGTHUMBNAILER}"
+            "WITH_EXIF=${WITH_EXIF}"
+            "WITH_EXIV2=${WITH_EXIV2}"
+            "WITH_PROTOCOL_EXTENSIONS=${WITH_PROTOCOL_EXTENSIONS}"
+            "WITH_LASTFM=${WITH_LASTFM}"
+            "WITH_LOGGING=${WITH_LOGGING}"
+            "WITH_DEBUG_LOGGING=${WITH_DEBUG_LOGGING}")
+
+    string (REPLACE ";" "\\n" COMPILE_INFO_STR "${COMPILE_INFO_LIST}")
+    set(COMPILE_INFO "${COMPILE_INFO_STR}" PARENT_SCOPE)
+
+
+    set(GIT_DIR "${CMAKE_SOURCE_DIR}/.git")
+
+    if(EXISTS "${GIT_DIR}")
+        # Get the current working branch
+        execute_process(
+                COMMAND git rev-parse --symbolic-full-name HEAD
+                WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+                OUTPUT_VARIABLE GIT_BRANCH
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+
+        # Get the latest commit hash
+        execute_process(
+                COMMAND git rev-parse HEAD
+                WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+                OUTPUT_VARIABLE GIT_COMMIT_HASH
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+    else()
+        set(GIT_BRANCH "")
+        set(GIT_COMMIT_HASH "")
+    endif()
+
+    set(GIT_BRANCH ${GIT_BRANCH} PARENT_SCOPE)
+    set(GIT_COMMIT_HASH ${GIT_COMMIT_HASH} PARENT_SCOPE)
+
+endfunction()

--- a/src/main.cc
+++ b/src/main.cc
@@ -96,13 +96,13 @@ int main(int argc, char** argv, char** envp)
         { (char*)"config", 1, nullptr, 'c' }, // 3
         { (char*)"home", 1, nullptr, 'm' }, // 4
         { (char*)"cfgdir", 1, nullptr, 'f' }, // 5
-        { (char*)"pidfile", 1, nullptr, 'P' }, // 8
-        { (char*)"add", 1, nullptr, 'a' }, // 9
-        { (char*)"logfile", 1, nullptr, 'l' }, // 10
-        { (char*)"debug", 0, nullptr, 'D' }, // 11
-        { (char*)"compile-info", 0, nullptr, 0 }, // 12
-        { (char*)"version", 0, nullptr, 0 }, // 13
-        { (char*)"help", 0, nullptr, 'h' }, // 14
+        { (char*)"pidfile", 1, nullptr, 'P' }, // 6
+        { (char*)"add", 1, nullptr, 'a' }, // 7
+        { (char*)"logfile", 1, nullptr, 'l' }, // 8
+        { (char*)"debug", 0, nullptr, 'D' }, // 9
+        { (char*)"compile-info", 0, nullptr, 0 }, // 10
+        { (char*)"version", 0, nullptr, 0 }, // 11
+        { (char*)"help", 0, nullptr, 'h' }, // 12
         { (char*)nullptr, 0, nullptr, 0 }
     };
 
@@ -230,11 +230,14 @@ For more information visit " DESC_MANUFACTURER_URL "\n\n");
             exit(EXIT_FAILURE);
         case 0:
             switch (opt_index) {
-            case 13: // --compile-info
+            case 10: // --compile-info
                 print_copyright();
                 printf("Compile info:\n");
                 printf("-------------\n");
-                printf("%s\n\n", COMPILE_INFO);
+                printf("%s\n\n",COMPILE_INFO);
+                printf("Git info:\n");
+                printf("-------------\n");
+                printf("Git Branch: %s\nGit Commit: %s\n\n", GIT_BRANCH, GIT_COMMIT_HASH);
                 exit(EXIT_SUCCESS);
             case 11: // --version
                 print_version = true;

--- a/src/main.cc
+++ b/src/main.cc
@@ -234,10 +234,12 @@ For more information visit " DESC_MANUFACTURER_URL "\n\n");
                 print_copyright();
                 printf("Compile info:\n");
                 printf("-------------\n");
-                printf("%s\n\n",COMPILE_INFO);
-                printf("Git info:\n");
-                printf("-------------\n");
-                printf("Git Branch: %s\nGit Commit: %s\n\n", GIT_BRANCH, GIT_COMMIT_HASH);
+                printf("%s\n\n", COMPILE_INFO);
+                if(strlen(GIT_BRANCH) > 0 || strlen(GIT_COMMIT_HASH) > 0) {
+                    printf("Git info:\n");
+                    printf("-------------\n");
+                    printf("Git Branch: %s\nGit Commit: %s\n\n", GIT_BRANCH, GIT_COMMIT_HASH);
+                }
                 exit(EXIT_SUCCESS);
             case 11: // --version
                 print_version = true;


### PR DESCRIPTION
I added a few new definitions to include the git information.
Testing consisted of running for about 1 hour, watched a few movies..

Here is a sample output for compile info:
```
/d/g/build> ./gerbera --compile-info

Gerbera UPnP Server version 1.1.0_alpha - http://gerbera.io/

===============================================================================
Gerbera is free software, covered by the GNU General Public License version 2

Copyright 2016-2017 Gerbera Contributors.
Gerbera is based on MediaTomb: Copyright 2005-2010 Gena Batsyan, Sergey Bostandzhyan, Leonhard Wimmer.
===============================================================================
Compile info:
-------------
WITH_MAGIC=1
WITH_MYSQL=1
WITH_CURL=1
WITH_INOTIFY=1
WITH_JS=1
WITH_TAGLIB=1
WITH_AVCODEC=1
WITH_FFMPEGTHUMBNAILER=0
WITH_EXIF=1
WITH_EXIV2=0
WITH_PROTOCOL_EXTENSIONS=1
WITH_LASTFM=0
WITH_LOGGING=1
WITH_DEBUG_LOGGING=1

Git info:
-------------
Git Branch: refs/heads/master
Git Commit: 5f9bce2720b938ebde4b656296f6d9cd5be0232d
```
