### PR TITLE
Fix native-uuid for Solaris/OmniOS

### DIFF
--- a/src/tools.cc
+++ b/src/tools.cc
@@ -54,6 +54,7 @@
     #include <fcntl.h>
     #include <net/if.h>
     #include <sys/sockio.h>
+    #include <uuid/uuid.h>
 #endif
 
 #include "md5/md5.h"


### PR DESCRIPTION
The changes to support "native uuid" once again broke Solaris/OmniOS
This should fix that