### PR TITLE
upnp includes no longer installs in "upnp-1.8" dir, but rather just upnp

### DIFF
--- a/src/action_request.h
+++ b/src/action_request.h
@@ -33,7 +33,7 @@
 #ifndef __ACTION_REQUEST_H__
 #define __ACTION_REQUEST_H__
 
-#include <upnp-1.8/upnp.h>
+#include <upnp/upnp.h>
 
 #include "common.h"
 #include "mxml/mxml.h"

--- a/src/buffered_io_handler.h
+++ b/src/buffered_io_handler.h
@@ -32,7 +32,7 @@
 #ifndef __BUFFERED_IO_HANDLER_H__
 #define __BUFFERED_IO_HANDLER_H__
 
-#include <upnp-1.8/upnp.h>
+#include <upnp/upnp.h>
 
 #include "common.h"
 #include "io_handler_buffer_helper.h"

--- a/src/curl_io_handler.h
+++ b/src/curl_io_handler.h
@@ -35,7 +35,7 @@
 #define __CURL_IO_HANDLER_H__
 
 #include <curl/curl.h>
-#include <upnp-1.8/upnp.h>
+#include <upnp/upnp.h>
 
 #include "common.h"
 #include "io_handler_buffer_helper.h"

--- a/src/file_io_handler.cc
+++ b/src/file_io_handler.cc
@@ -34,7 +34,7 @@
 #include <unistd.h>
 #include <cstring>
 #include <cstdio>
-#include <upnp-1.8/ixml.h>
+#include <upnp/ixml.h>
 
 #include "server.h"
 #include "common.h"

--- a/src/io_handler.cc
+++ b/src/io_handler.cc
@@ -31,7 +31,7 @@
 /// This handles the VirtualDirCallbacks that come from the web server.
 
 #include <unistd.h>
-#include <upnp-1.8/ixml.h>
+#include <upnp/ixml.h>
 
 #include "server.h"
 

--- a/src/io_handler.h
+++ b/src/io_handler.h
@@ -32,7 +32,7 @@
 #ifndef __IO_HANDLER_H__
 #define __IO_HANDLER_H__
 
-#include <upnp-1.8/upnp.h>
+#include <upnp/upnp.h>
 
 #include "common.h"
 

--- a/src/io_handler_buffer_helper.h
+++ b/src/io_handler_buffer_helper.h
@@ -33,7 +33,7 @@
 #define __IO_HANDLER_BUFFER_HELPER_H__
 
 #include <pthread.h>
-#include <upnp-1.8/upnp.h>
+#include <upnp/upnp.h>
 #include <mutex>
 #include <condition_variable>
 

--- a/src/mem_io_handler.cc
+++ b/src/mem_io_handler.cc
@@ -36,7 +36,7 @@
 #include <unistd.h>
 #include <cstring>
 #include <cstdio>
-#include <upnp-1.8/ixml.h>
+#include <upnp/ixml.h>
 #include <ctime>
 #include "common.h"
 #include "storage.h"

--- a/src/subscription_request.h
+++ b/src/subscription_request.h
@@ -33,7 +33,7 @@
 #ifndef __SUBSCRIPTION_REQUEST_H__
 #define __SUBSCRIPTION_REQUEST_H__
 
-#include <upnp-1.8/upnp.h>
+#include <upnp/upnp.h>
 
 #include "common.h"
 

--- a/src/transcoding/transcode_ext_handler.cc
+++ b/src/transcoding/transcode_ext_handler.cc
@@ -36,7 +36,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <upnp-1.8/ixml.h>
+#include <upnp/ixml.h>
 #include <unistd.h>
 #include <cstring>
 #include <cstdio>

--- a/src/transcoding/transcode_ext_handler.h
+++ b/src/transcoding/transcode_ext_handler.h
@@ -32,7 +32,7 @@
 #ifndef __TRANSCODE_EXTERNAL_HANDLER_H__
 #define __TRANSCODE_EXTERNAL_HANDLER_H__
 
-#include <upnp-1.8/upnp.h>
+#include <upnp/upnp.h>
 
 #include "common.h"
 #include "transcode_handler.h"

--- a/src/transcoding/transcode_handler.h
+++ b/src/transcoding/transcode_handler.h
@@ -32,7 +32,7 @@
 #ifndef __TRANSCODE_HANDLER_H__
 #define __TRANSCODE_HANDLER_H__
 
-#include <upnp-1.8/upnp.h>
+#include <upnp/upnp.h>
 
 #include "common.h"
 #include "io_handler.h"

--- a/src/url_request_handler.cc
+++ b/src/url_request_handler.cc
@@ -31,7 +31,7 @@
 
 #ifdef HAVE_CURL
 
-#include <upnp-1.8/ixml.h>
+#include <upnp/ixml.h>
 
 #include "server.h"
 #include "common.h"


### PR DESCRIPTION
Tracking latest upnp, i noticed it no longer installs headers in "upnp-1.8".
You won't notice this if you've updated, as the old -1.8 include subdir is not
removed, leading to a dangerous case of versionitis.